### PR TITLE
Add disabling on `--no-dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Composer Local Repositories
+
+The composer plugin to quickly add local repositories for development purposes, without the need to update
+your `composer.json` file.
+
+## How to install
+
+```bash
+composer require --global ollieread/composer-local-repositories
+```
+
+## How to use
+
+Add a `repositories.json` file to any project that you want to add a custom repository to. The file needs to contain a
+valid composer `repositories` key. For example:
+
+**`repositories.json`**
+
+```json
+{
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../local-folder"
+    }
+  ]
+}
+```
+
+During a `composer install` or `composer update`, the plugin will locate the `repositories.json` file; and prepend all
+the configured repositories. If composer finds any of the `require` package inside these repositories, it will install
+the package from that repository instead.
+
+## Configuration
+
+To configure the plugin, you can provide extra configuration keys under a `local-repositories` key in the `extra`
+section.
+
+- `trigger-commands` An array of composer commands that loads the local `repositories.json` file (default: `install`
+  and `update`)
+- `ignore-flags` An array of flags on which to ignore the local `repositories.json` file (default: `--no-dev`
+  and `--prefer-source`)
+- `force-dev` Whether to update the constraint of any found packages from local repositories with `@dev` (
+  default: `true`)
+
+Full configuration example with default values:
+
+**global `composer.json`**
+
+```json
+{
+  "extra": {
+    "local-repositories": {
+      "trigger-commands": [
+        "install",
+        "update"
+      ],
+      "ignore-flags": [
+        "no-dev",
+        "prefer-source"
+      ],
+      "force-dev": true
+    }
+  }
+}
+```

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "composer-plugin-api": "^2.6"
   },
   "require-dev"      : {
-    "composer/composer": "^2.7"
+    "composer/composer": "^2.7",
+    "phpstan/phpstan": "^1.11"
   },
   "license"          : "MIT",
   "autoload"         : {
@@ -19,10 +20,17 @@
     {
       "name" : "Ollie",
       "email": "code@ollie.codes"
+    },
+    {
+      "name": "Doeke Norg",
+      "email": "mail@doeken.org"
     }
   ],
   "minimum-stability": "stable",
   "extra"            : {
-    "class": "Ollieread\\ComposerLocalRepositories\\LocalRepositoryPlugin"
+    "class": "Ollieread\\ComposerLocalRepositories\\LocalRepositoriesPlugin"
+  },
+  "scripts": {
+    "analyse": "vendor/bin/phpstan analyse"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17210e27b4b4e369507fed71b4dc1e08",
+    "content-hash": "d73ff75ace72045782c8a3c09f11e81e",
     "packages": [],
     "packages-dev": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "0c5ccfcfea312b5c5a190a21ac5cef93f74baf99"
+                "reference": "063d9aa8696582f5a41dffbbaf3c81024f0a604a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/0c5ccfcfea312b5c5a190a21ac5cef93f74baf99",
-                "reference": "0c5ccfcfea312b5c5a190a21ac5cef93f74baf99",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/063d9aa8696582f5a41dffbbaf3c81024f0a604a",
+                "reference": "063d9aa8696582f5a41dffbbaf3c81024f0a604a",
                 "shasum": ""
             },
             "require": {
@@ -28,7 +28,7 @@
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.10",
-                "psr/log": "^1.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "symfony/phpunit-bridge": "^4.2 || ^5",
                 "symfony/process": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
@@ -65,7 +65,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.0"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.1"
             },
             "funding": [
                 {
@@ -81,7 +81,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-15T14:00:32+00:00"
+            "time": "2024-07-08T15:28:20+00:00"
         },
         {
             "name": "composer/class-map-generator",
@@ -158,48 +158,48 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.7.7",
+            "version": "2.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "291942978f39435cf904d33739f98d7d4eca7b23"
+                "reference": "a2edd4e4414c17008ab585e0c62574fdb644ebfc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/291942978f39435cf904d33739f98d7d4eca7b23",
-                "reference": "291942978f39435cf904d33739f98d7d4eca7b23",
+                "url": "https://api.github.com/repos/composer/composer/zipball/a2edd4e4414c17008ab585e0c62574fdb644ebfc",
+                "reference": "a2edd4e4414c17008ab585e0c62574fdb644ebfc",
                 "shasum": ""
             },
             "require": {
-                "composer/ca-bundle": "^1.0",
+                "composer/ca-bundle": "^1.5",
                 "composer/class-map-generator": "^1.3.3",
                 "composer/metadata-minifier": "^1.0",
-                "composer/pcre": "^2.1 || ^3.1",
+                "composer/pcre": "^2.2 || ^3.2",
                 "composer/semver": "^3.3",
                 "composer/spdx-licenses": "^1.5.7",
                 "composer/xdebug-handler": "^2.0.2 || ^3.0.3",
-                "justinrainbow/json-schema": "^5.2.11",
+                "justinrainbow/json-schema": "^5.3",
                 "php": "^7.2.5 || ^8.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
-                "react/promise": "^2.8 || ^3",
+                "react/promise": "^3.2",
                 "seld/jsonlint": "^1.4",
                 "seld/phar-utils": "^1.2",
                 "seld/signal-handler": "^2.0",
-                "symfony/console": "^5.4.11 || ^6.0.11 || ^7",
-                "symfony/filesystem": "^5.4 || ^6.0 || ^7",
-                "symfony/finder": "^5.4 || ^6.0 || ^7",
+                "symfony/console": "^5.4.35 || ^6.3.12 || ^7.0.3",
+                "symfony/filesystem": "^5.4.35 || ^6.3.12 || ^7.0.3",
+                "symfony/finder": "^5.4.35 || ^6.3.12 || ^7.0.3",
                 "symfony/polyfill-php73": "^1.24",
                 "symfony/polyfill-php80": "^1.24",
                 "symfony/polyfill-php81": "^1.24",
-                "symfony/process": "^5.4 || ^6.0 || ^7"
+                "symfony/process": "^5.4.35 || ^6.3.12 || ^7.0.3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.11.0",
+                "phpstan/phpstan": "^1.11.8",
                 "phpstan/phpstan-deprecation-rules": "^1.2.0",
                 "phpstan/phpstan-phpunit": "^1.4.0",
                 "phpstan/phpstan-strict-rules": "^1.6.0",
                 "phpstan/phpstan-symfony": "^1.4.0",
-                "symfony/phpunit-bridge": "^6.4.1 || ^7.0.1"
+                "symfony/phpunit-bridge": "^6.4.3 || ^7.0.1"
             },
             "suggest": {
                 "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
@@ -252,7 +252,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.7.7"
+                "source": "https://github.com/composer/composer/tree/2.7.8"
             },
             "funding": [
                 {
@@ -268,7 +268,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-10T20:11:12+00:00"
+            "time": "2024-08-22T13:28:36+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -341,30 +341,38 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.1.4",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "04229f163664973f68f38f6f73d917799168ef24"
+                "reference": "1637e067347a0c40bbb1e3cd786b20dcab556a81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/04229f163664973f68f38f6f73d917799168ef24",
-                "reference": "04229f163664973f68f38f6f73d917799168ef24",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/1637e067347a0c40bbb1e3cd786b20dcab556a81",
+                "reference": "1637e067347a0c40bbb1e3cd786b20dcab556a81",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
             "require-dev": {
-                "phpstan/phpstan": "^1.3",
+                "phpstan/phpstan": "^1.11.10",
                 "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^5"
+                "phpunit/phpunit": "^8 || ^9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
                     "dev-main": "3.x-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
                 }
             },
             "autoload": {
@@ -392,7 +400,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.4"
+                "source": "https://github.com/composer/pcre/tree/3.3.0"
             },
             "funding": [
                 {
@@ -408,20 +416,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-27T13:40:54+00:00"
+            "time": "2024-08-19T19:43:53+00:00"
         },
         {
             "name": "composer/semver",
-            "version": "3.4.0",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
+                "reference": "c51258e759afdb17f1fd1fe83bc12baaef6309d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
-                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c51258e759afdb17f1fd1fe83bc12baaef6309d6",
+                "reference": "c51258e759afdb17f1fd1fe83bc12baaef6309d6",
                 "shasum": ""
             },
             "require": {
@@ -473,7 +481,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.0"
+                "source": "https://github.com/composer/semver/tree/3.4.2"
             },
             "funding": [
                 {
@@ -489,7 +497,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-31T09:50:34+00:00"
+            "time": "2024-07-12T11:35:52+00:00"
         },
         {
             "name": "composer/spdx-licenses",
@@ -639,20 +647,20 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "v5.2.13",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "fbbe7e5d79f618997bc3332a6f49246036c45793"
+                "reference": "feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/fbbe7e5d79f618997bc3332a6f49246036c45793",
-                "reference": "fbbe7e5d79f618997bc3332a6f49246036c45793",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8",
+                "reference": "feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
@@ -663,11 +671,6 @@
                 "bin/validate-json"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "JsonSchema\\": "src/JsonSchema/"
@@ -703,22 +706,22 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/v5.2.13"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/5.3.0"
             },
-            "time": "2023-09-26T02:20:38+00:00"
+            "time": "2024-07-06T21:00:26+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.10",
+            "version": "1.11.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "640410b32995914bde3eed26fa89552f9c2c082f"
+                "reference": "707c2aed5d8d0075666e673a5e71440c1d01a5a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/640410b32995914bde3eed26fa89552f9c2c082f",
-                "reference": "640410b32995914bde3eed26fa89552f9c2c082f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/707c2aed5d8d0075666e673a5e71440c1d01a5a3",
+                "reference": "707c2aed5d8d0075666e673a5e71440c1d01a5a3",
                 "shasum": ""
             },
             "require": {
@@ -763,7 +766,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-08T09:02:50+00:00"
+            "time": "2024-08-19T14:37:29+00:00"
         },
         {
             "name": "psr/container",
@@ -820,16 +823,16 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "79dff0b268932c640297f5208d6298f71855c03e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/79dff0b268932c640297f5208d6298f71855c03e",
+                "reference": "79dff0b268932c640297f5208d6298f71855c03e",
                 "shasum": ""
             },
             "require": {
@@ -864,9 +867,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/3.0.1"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2024-08-21T13:31:24+00:00"
         },
         {
             "name": "react/promise",
@@ -943,23 +946,23 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.10.2",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "9bb7db07b5d66d90f6ebf542f09fc67d800e5259"
+                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9bb7db07b5d66d90f6ebf542f09fc67d800e5259",
-                "reference": "9bb7db07b5d66d90f6ebf542f09fc67d800e5259",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/1748aaf847fc731cfad7725aec413ee46f0cc3a2",
+                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan": "^1.11",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^8.5.13"
             },
             "bin": [
@@ -991,7 +994,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.10.2"
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.11.0"
             },
             "funding": [
                 {
@@ -1003,7 +1006,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-07T12:57:50+00:00"
+            "time": "2024-07-11T14:55:45+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -1116,16 +1119,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.1.1",
+            "version": "v7.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "9b008f2d7b21c74ef4d0c3de6077a642bc55ece3"
+                "reference": "cb1dcb30ebc7005c29864ee78adb47b5fb7c3cd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/9b008f2d7b21c74ef4d0c3de6077a642bc55ece3",
-                "reference": "9b008f2d7b21c74ef4d0c3de6077a642bc55ece3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cb1dcb30ebc7005c29864ee78adb47b5fb7c3cd9",
+                "reference": "cb1dcb30ebc7005c29864ee78adb47b5fb7c3cd9",
                 "shasum": ""
             },
             "require": {
@@ -1189,7 +1192,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.1.1"
+                "source": "https://github.com/symfony/console/tree/v7.1.3"
             },
             "funding": [
                 {
@@ -1205,7 +1208,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:57:53+00:00"
+            "time": "2024-07-26T12:41:01+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1276,16 +1279,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.1.1",
+            "version": "v7.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "802e87002f919296c9f606457d9fa327a0b3d6b2"
+                "reference": "92a91985250c251de9b947a14bb2c9390b1a562c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/802e87002f919296c9f606457d9fa327a0b3d6b2",
-                "reference": "802e87002f919296c9f606457d9fa327a0b3d6b2",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/92a91985250c251de9b947a14bb2c9390b1a562c",
+                "reference": "92a91985250c251de9b947a14bb2c9390b1a562c",
                 "shasum": ""
             },
             "require": {
@@ -1322,7 +1325,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.1.1"
+                "source": "https://github.com/symfony/filesystem/tree/v7.1.2"
             },
             "funding": [
                 {
@@ -1338,20 +1341,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:57:53+00:00"
+            "time": "2024-06-28T10:03:55+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.1.1",
+            "version": "v7.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "fbb0ba67688b780efbc886c1a0a0948dcf7205d6"
+                "reference": "717c6329886f32dc65e27461f80f2a465412fdca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/fbb0ba67688b780efbc886c1a0a0948dcf7205d6",
-                "reference": "fbb0ba67688b780efbc886c1a0a0948dcf7205d6",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/717c6329886f32dc65e27461f80f2a465412fdca",
+                "reference": "717c6329886f32dc65e27461f80f2a465412fdca",
                 "shasum": ""
             },
             "require": {
@@ -1386,7 +1389,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.1.1"
+                "source": "https://github.com/symfony/finder/tree/v7.1.3"
             },
             "funding": [
                 {
@@ -1402,7 +1405,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:57:53+00:00"
+            "time": "2024-07-24T07:08:44+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1956,16 +1959,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.1.1",
+            "version": "v7.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "febf90124323a093c7ee06fdb30e765ca3c20028"
+                "reference": "7f2f542c668ad6c313dc4a5e9c3321f733197eca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/febf90124323a093c7ee06fdb30e765ca3c20028",
-                "reference": "febf90124323a093c7ee06fdb30e765ca3c20028",
+                "url": "https://api.github.com/repos/symfony/process/zipball/7f2f542c668ad6c313dc4a5e9c3321f733197eca",
+                "reference": "7f2f542c668ad6c313dc4a5e9c3321f733197eca",
                 "shasum": ""
             },
             "require": {
@@ -1997,7 +2000,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.1.1"
+                "source": "https://github.com/symfony/process/tree/v7.1.3"
             },
             "funding": [
                 {
@@ -2013,7 +2016,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:57:53+00:00"
+            "time": "2024-07-26T12:44:47+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -2100,16 +2103,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.1.1",
+            "version": "v7.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "60bc311c74e0af215101235aa6f471bcbc032df2"
+                "reference": "ea272a882be7f20cad58d5d78c215001617b7f07"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/60bc311c74e0af215101235aa6f471bcbc032df2",
-                "reference": "60bc311c74e0af215101235aa6f471bcbc032df2",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ea272a882be7f20cad58d5d78c215001617b7f07",
+                "reference": "ea272a882be7f20cad58d5d78c215001617b7f07",
                 "shasum": ""
             },
             "require": {
@@ -2167,7 +2170,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.1.1"
+                "source": "https://github.com/symfony/string/tree/v7.1.3"
             },
             "funding": [
                 {
@@ -2183,7 +2186,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-04T06:40:14+00:00"
+            "time": "2024-07-22T10:25:37+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ce7dd274c3f21c93b06c690600926cc",
+    "content-hash": "17210e27b4b4e369507fed71b4dc1e08",
     "packages": [],
     "packages-dev": [
         {
@@ -706,6 +706,64 @@
                 "source": "https://github.com/jsonrainbow/json-schema/tree/v5.2.13"
             },
             "time": "2023-09-26T02:20:38+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.11.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "640410b32995914bde3eed26fa89552f9c2c082f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/640410b32995914bde3eed26fa89552f9c2c082f",
+                "reference": "640410b32995914bde3eed26fa89552f9c2c082f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-08T09:02:50+00:00"
         },
         {
             "name": "psr/container",

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,7 @@
+includes:
+    - vendor/composer/composer/phpstan/rules.neon
+
+parameters:
+	level: 8
+	paths:
+		- src

--- a/src/LocalRepositoriesPlugin.php
+++ b/src/LocalRepositoriesPlugin.php
@@ -1,33 +1,109 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Ollieread\ComposerLocalRepositories;
 
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
-use Composer\Factory;
 use Composer\IO\IOInterface;
 use Composer\Json\JsonFile;
+use Composer\Json\JsonValidationException;
+use Composer\Plugin\CommandEvent;
+use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PluginInterface;
+use Seld\JsonLint\ParsingException;
 
 class LocalRepositoriesPlugin implements PluginInterface, EventSubscriberInterface
 {
-    /**
-     * @var \Composer\Composer
-     */
     private Composer $composer;
-
-    /**
-     * @var \Composer\IO\IOInterface
-     */
     private IOInterface $io;
-
-    private array $repositories = [];
+    private bool $is_main_composer;
 
     public function activate(Composer $composer, IOInterface $io): void
     {
         $this->composer = $composer;
-        $this->io       = $io;
+        $this->io = $io;
+        // Composer runs copies of itself inside the run. We use this to prevent writing the same output multiple times.
+        $this->is_main_composer = !str_contains(get_class($this), '_composer_tmp');
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PluginEvents::COMMAND => 'loadRepositories',
+        ];
+    }
+
+    public function loadRepositories(CommandEvent $event): void
+    {
+        if (
+            !in_array($event->getCommandName(), ['install', 'update'], true)
+            || $event->getInput()->getOption('no-dev')
+        ) {
+            return;
+        }
+
+        // Get root path according to Composer (when providing the path to the binary).
+        $rootPath = dirname($this->composer->getConfig()->getConfigSource()->getName());
+        $packagesPath = $rootPath . DIRECTORY_SEPARATOR . 'repositories.json';
+
+        if (!file_exists($packagesPath)) {
+            if ($this->is_main_composer) {
+                $this->io->write('<info>No local repositories.json available</info>', true, IOInterface::VERBOSE);
+            }
+            return;
+        }
+
+        if ($this->is_main_composer) {
+            $this->io->write('<info>Local repositories.json available</info>');
+        }
+
+        $this->loadPackagesFrom($packagesPath);
+    }
+
+    private function loadPackagesFrom(string $path): void
+    {
+        try {
+            $json = new JsonFile($path);
+            $json->validateSchema(JsonFile::LAX_SCHEMA, __DIR__ . '/../resources/composer-repositories-schema.json');
+            $contents = $json->read();
+        } catch (JsonValidationException|ParsingException $e) {
+            $this->io->writeError($e->getMessage());
+            return;
+        }
+
+        if (isset($contents['repositories'])) {
+            // The reverse is important so that their priority matches the order
+            // they're defined in.
+            $repositories = array_reverse($contents['repositories']);
+
+            $this->io->write('<info>Repositories found:</info> ' . count($repositories), true, IOInterface::VERBOSE);
+
+            foreach ($repositories as $name => $config) {
+                $this->loadRepository($name, $config);
+            }
+        }
+    }
+
+    /**
+     * @param array{type: ?string, url: string } $config
+     */
+    private function loadRepository(int|string $name, array $config): void
+    {
+        $manager = $this->composer->getRepositoryManager();
+
+        $repository = $manager->createRepository(
+            $config['type'] ?? 'path', // If there's no type, it's path-based
+            $config,
+            is_string($name) ? $name : null,
+        );
+
+        $this->io->write('<info>Adding repository:</info> ' . $repository->getRepoName());
+
+        $manager->prependRepository($repository);
+
+        $this->io->write('Repository added successfully', true, IOInterface::VERBOSE);
     }
 
     public function deactivate(Composer $composer, IOInterface $io): void
@@ -38,80 +114,5 @@ class LocalRepositoriesPlugin implements PluginInterface, EventSubscriberInterfa
     public function uninstall(Composer $composer, IOInterface $io): void
     {
         // This is intentionally empty
-    }
-
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            'init' => 'loadRepositories',
-        ];
-    }
-
-    /**
-     * @return void
-     * @throws \Composer\Json\JsonValidationException
-     * @throws \JsonException
-     */
-    public function loadRepositories(): void
-    {
-        $rootPath     = dirname(Factory::getComposerFile());
-        $packagesPath = $rootPath . DIRECTORY_SEPARATOR . 'repositories.json';
-
-        if (! file_exists($packagesPath)) {
-            $this->io->writeError('<info>No local repositories.json available</info>');
-        } else {
-            $this->io->writeError('<info>Local repositories.json available</info>');
-
-            $this->loadPackagesFrom($packagesPath);
-        }
-    }
-
-    /**
-     * @throws \Composer\Json\JsonValidationException
-     * @throws \JsonException
-     */
-    private function loadPackagesFrom(string $path): void
-    {
-        // Get the contents of the file
-        $contents = json_decode(file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
-
-        // Validate the schema, to make sure it's valid
-        JsonFile::validateJsonSchema(
-            $path,
-            $contents,
-            JsonFile::LAX_SCHEMA,
-            __DIR__ . '/../resources/composer-repositories-schema.json'
-        );
-
-        if (isset($contents['repositories'])) {
-            // The reverse is important so that their priority matches the order
-            // they're defined in.
-            $repositories = array_reverse($contents['repositories']);
-
-            $this->io->writeError('<info>Repositories found:</info> ' . count($repositories));
-
-            foreach ($repositories as $name => $config) {
-                $this->loadRepository($name, $config);
-            }
-        }
-    }
-
-    private function loadRepository(int|string $name, array $config): void
-    {
-        $manager = $this->composer->getRepositoryManager();
-
-        $repository = $manager->createRepository(
-            $config['type'] ?? 'path', // If there's no type, it's path-based
-            $config,
-            $name
-        );
-
-        $this->io->writeError('<info>Adding repository:</info> ' . $repository->getRepoName());
-
-        $this->repositories[] = $repository;
-
-        $manager->prependRepository($repository);
-
-        $this->io->writeError('Repository added successfully');
     }
 }

--- a/src/LocalRepositoriesPlugin.php
+++ b/src/LocalRepositoriesPlugin.php
@@ -18,14 +18,11 @@ class LocalRepositoriesPlugin implements PluginInterface, EventSubscriberInterfa
 {
     private Composer $composer;
     private IOInterface $io;
-    private bool $is_main_composer;
 
     public function activate(Composer $composer, IOInterface $io): void
     {
         $this->composer = $composer;
         $this->io = $io;
-        // Composer runs copies of itself inside the run. We use this to prevent writing the same output multiple times.
-        $this->is_main_composer = !str_contains(get_class($this), '_composer_tmp');
     }
 
     public static function getSubscribedEvents(): array
@@ -49,16 +46,11 @@ class LocalRepositoriesPlugin implements PluginInterface, EventSubscriberInterfa
         $packagesPath = $rootPath . DIRECTORY_SEPARATOR . 'repositories.json';
 
         if (!file_exists($packagesPath)) {
-            if ($this->is_main_composer) {
-                $this->io->write('<info>No local repositories.json available</info>', true, IOInterface::VERBOSE);
-            }
+            $this->io->write('<info>No local repositories.json available</info>', true, IOInterface::VERBOSE);
             return;
         }
 
-        if ($this->is_main_composer) {
-            $this->io->write('<info>Local repositories.json available</info>');
-        }
-
+        $this->io->write('<info>Local repositories.json available</info>');
         $this->loadPackagesFrom($packagesPath);
     }
 


### PR DESCRIPTION
Hey @ollieread, 

As promised a PR to be able to disable the behavior.

Unfortunately Composer does not allow adding extra arguments / options to a command. That's why I think it makes sense to listen to `--no-dev` as this plugin is useful for development environments. This is also why I moved event-listener from `init` to `PluginEvents::Command`. This prevents unnecessary extra registers for other commands, as the repositories are only useful during `install` and `update` (works for `i` and `u` as well).

I did some refactoring of the code (PSR-12), hope you don't mind. And I saw they provide a PHPstan file; so I figured I'd add PHPStan and add a helper command (`composer analyse`).

- Resolve composer path via the current instance
- Deduplicate info messages
- Put some messages behind a `verbose` flag
- Moved action to `install` and `update` only to be able to intercept the `--no-dev` flag
- Reading json via JsonFile to avoid errors
- Fixed plugin name in composer.json
- Added PHPStan rules and `analyse` script